### PR TITLE
fix: correct API response handling in payment confirmation

### DIFF
--- a/src/app/_components/PaymentConfirmation.tsx
+++ b/src/app/_components/PaymentConfirmation.tsx
@@ -1,76 +1,80 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 export default function PaymentConfirmation() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const reference = searchParams.get("reference");
+  const reference = searchParams.get('reference');
 
   const [status, setStatus] = useState<
-    "loading" | "success" | "pending" | "failed"
-  >("loading");
-  const [retries, setRetries] = useState(0);
+    'loading' | 'success' | 'pending' | 'failed'
+  >('loading');
+  const retriesRef = useRef(0);
+  const timeOutRef = useRef<NodeJS.Timeout | null>(null);
   const maxRetries = 5;
 
-  const fetchStatus = async () => {
+  const fetchStatus = useCallback(async () => {
     try {
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_BASE_URL}/api/confirm-payment/${reference}`,
         {
-          credentials: "include",
-        }
+          credentials: 'include',
+        },
       );
 
-      const data = await res.json();
-      console.log("API Response:", data);
+      const { confirmation: data } = await res.json();
 
-      if (data.status === "success") {
-        const type = data.transaction?.type;
+      if (data.status === 'success') {
+        setStatus('success');
+        const type = data?.type;
 
-        if (type === "escrow" || type === "escrows") {
-          const escrowId = data.escrowId;
+        if (type === 'escrow_payment' || type === 'escrow') {
+          const escrowId = data.escrow;
           router.push(`/dashboard/escrows/${escrowId}`);
-        } else if (type === "addfunds") {
+        } else if (type === 'addfunds') {
           router.push(`/dashboard/wallet`);
         } else {
-          setStatus("failed");
+          setStatus('failed');
         }
-      } else if (data.status === "pending") {
-        if (retries < maxRetries) {
-          setTimeout(() => {
-            setRetries((prev) => prev + 1);
-            fetchStatus(); // Retry after delay
-          }, 2000);
+      } else if (data.status === 'pending') {
+        setStatus('pending');
+        if (retriesRef.current < maxRetries) {
+          retriesRef.current++;
+          timeOutRef.current = setTimeout(fetchStatus, 2000);
         } else {
-          setStatus("failed");
+          setStatus('failed');
         }
       } else {
-        setStatus("failed");
+        setStatus('failed');
       }
     } catch (error) {
-      console.error("Error fetching payment status:", error);
-      setStatus("failed");
+      console.error('Error fetching payment status:', error);
+      setStatus('failed');
     }
-  };
+  }, [reference, router]);
 
   useEffect(() => {
     if (reference) {
       fetchStatus();
     }
-  }, [reference]);
+
+    return () => {
+      if (timeOutRef.current) clearTimeout(timeOutRef.current);
+    };
+  }, [reference, fetchStatus]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4">
-      {status === "loading" || status === "pending" ? (
+    <div className='min-h-screen flex flex-col items-center justify-center text-center px-4'>
+      {status === 'loading' || status === 'pending' ? (
         <div>
-          <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-accent mx-auto mb-4"></div>
-          <p className="text-lg font-semibold">Verifying your payment...</p>
+          <div className='animate-spin rounded-full h-16 w-16 border-t-4 border-accent mx-auto mb-4'></div>
+          <p className='text-lg font-semibold'>Verifying your payment...</p>
         </div>
-      ) : status === "failed" ? (
-        <div className="text-yellow-600">
-          <h2 className="text-2xl font-bold mb-2">Still Processing</h2>
+      ) : status === 'failed' ? (
+        <div className='text-yellow-600'>
+          <h2 className='text-2xl font-bold mb-2'>Still Processing</h2>
           <p>
             Please check your dashboard for the latest update on your payment.
           </p>

--- a/src/app/_lib/userDashboardServices.ts
+++ b/src/app/_lib/userDashboardServices.ts
@@ -229,3 +229,5 @@ export async function payEscrowBillApi(payload: {
     );
   }
 }
+
+


### PR DESCRIPTION
Adjusted payment confirmation logic to extract fields from `confirmation` object instead of root response. Previously, `status` and `type` checks were failing due to incorrect data mapping, causing router navigation to never trigger. Added stable retry mechanism using refs and cleanup.